### PR TITLE
Fix sync_instructions default path to ~/.claude/CLAUDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add to your Claude Code config:
 }
 ```
 
-Tell Claude how to use it. Drop this in your global `~/CLAUDE.md` (your home directory, not per-project):
+Tell Claude how to use it. Drop this in your global `~/.claude/CLAUDE.md` (your home directory, not per-project):
 
 ```markdown
 ## Memory
@@ -42,7 +42,7 @@ Tell Claude how to use it. Drop this in your global `~/CLAUDE.md` (your home dir
 - After completing significant work, call `remember` to store decisions and outcomes
 ```
 
-Or just let Zikkaron handle it. On every startup, it automatically syncs `~/CLAUDE.md` with the latest instructions via `sync_instructions`. You set it up once and never think about it again.
+Or just let Zikkaron handle it. On every startup, it automatically syncs `~/.claude/CLAUDE.md` with the latest instructions via `sync_instructions`. You set it up once and never think about it again.
 
 ## What this actually feels like
 

--- a/zikkaron/server.py
+++ b/zikkaron/server.py
@@ -1044,9 +1044,15 @@ def sync_instructions(claude_md_path: str = "") -> dict:
     and updates it with the latest tools, capabilities, and rules.
     Call this on session start or after Zikkaron updates.
 
-    claude_md_path: Path to CLAUDE.md. Defaults to ~/CLAUDE.md
+    claude_md_path: Path to CLAUDE.md. Defaults to ~/.claude/CLAUDE.md
     """
-    md_path = Path(claude_md_path) if claude_md_path else Path.home() / "CLAUDE.md"
+    md_path = Path(claude_md_path) if claude_md_path else Path.home() / ".claude" / "CLAUDE.md"
+
+    if not md_path.parent.is_dir():
+        return {
+            "status": "skipped",
+            "reason": f"Directory {md_path.parent} does not exist",
+        }
 
     # The canonical Zikkaron section
     zikkaron_section = f"""## Memory System — Zikkaron v{__version__}


### PR DESCRIPTION
## Summary
- `sync_instructions` defaulted to `~/CLAUDE.md`, but Claude Code's global instructions live at `~/.claude/CLAUDE.md`
- Gracefully skip writing when the parent directory doesn't exist (i.e. Claude Code not installed) instead of erroring
- Updated README references to match

Fixes #1