### PR TITLE
Document that remember() context must be a directory path

### DIFF
--- a/zikkaron/server.py
+++ b/zikkaron/server.py
@@ -275,7 +275,12 @@ def _file_hash(filepath: str) -> str | None:
 
 @mcp_server.tool()
 def remember(content: str, context: str, tags: list[str]) -> dict:
-    """Store a new memory with embedding and optional file hash."""
+    """Store a new memory with embedding and optional file hash.
+
+    context MUST be the actual working directory path (e.g., '/home/user/projects/myapp'),
+    NOT a description. get_project_context() filters by directory path match —
+    descriptive strings will make memories unfindable by project.
+    """
     storage = _get_storage()
     embeddings = _get_embeddings()
     buffer = _get_buffer()
@@ -1248,6 +1253,7 @@ def sync_instructions(claude_md_path: str = "") -> dict:
 - NEVER rely on CLAUDE.md or built-in memory for cross-session context — use Zikkaron
 - Before starting any task, call `get_project_context` for the current working directory
 - After completing any significant task, call `remember` to store what was done, decisions made, and outcomes
+- CRITICAL: The `context` parameter in `remember` MUST be the actual working directory path (e.g., `/home/user/projects/myapp`), NEVER a description. `get_project_context` filters by exact directory path match — descriptive strings break it.
 - Zikkaron is your brain. Use it.
 
 ### Hippocampal Replay — Context Compaction Shield
@@ -1260,7 +1266,7 @@ def sync_instructions(claude_md_path: str = "") -> dict:
 - `restore` returns: checkpoint + anchored memories + hot context + SR predictions + gap detection
 
 ### Available Tools
-- `remember(content, context, tags)` — Store memory with write gate
+- `remember(content, context, tags)` — Store memory with write gate. `context` MUST be a directory path (e.g., `/home/user/projects/myapp`), not a description.
 - `recall(query, max_results, min_heat)` — Multi-signal retrieval
 - `get_project_context(directory)` — Hot memories for directory
 - `checkpoint(directory, ...)` — Snapshot working state


### PR DESCRIPTION
## Summary
- `get_project_context()` filters by exact `directory_context = ?` match in SQLite, but nothing told LLMs that the `context` param in `remember()` needs to be an actual directory path! Result: memory often stored with a descriptive string (e.g., "User feedback on workflow preferences") and was invisible to `get_project_context()`.
- Updated the `remember()` tool docstring so LLMs see the requirement in the tool schema
- Added the rule to the `sync_instructions` template so it propagates to every user's CLAUDE.md
- Updated the tool listing in the same template for consistency

## Test plan
- [x] Called `remember()` with a real directory path as `context`
- [x] Called `get_project_context()` with the same path — memory was returned
- [x] Verified against v1.3.0 codebase (rebased on latest upstream)